### PR TITLE
Fix cross compilation with mingw

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -422,7 +422,7 @@ need_glx_functions = false
 if ['auto', 'gl'].contains(gl_backend)
   gl_dep = dependency('gl', required: gl_backend == 'gl')
   if not gl_dep.found()
-    if cc.has_header('GL/gl.h')
+    if cc.has_header('GL/gl.h') and host_machine.system() != 'windows'
       gl_extra_libs = ['-lGL']
       gl_requires = ''
       extra_link_args += gl_extra_libs

--- a/subprojects/glib.wrap
+++ b/subprojects/glib.wrap
@@ -1,5 +1,5 @@
 [wrap-git]
 directory=glib
-url=git://git.gnome.org/glib
-push-url=ssh://git.gnome.org/git/glib
-revision=master
+url=https://gitlab.gnome.org/GNOME/glib.git
+push-url=ssh://git@gitlab.gnome.org:GNOME/glib.git
+revision=origin/master

--- a/subprojects/libpng.wrap
+++ b/subprojects/libpng.wrap
@@ -1,10 +1,10 @@
 [wrap-file]
-directory = libpng-1.6.34
+directory = libpng-1.6.35
 
-source_url = ftp://ftp-osl.osuosl.org/pub/libpng/src/libpng16/libpng-1.6.34.tar.xz
-source_filename = libpng-1.6.34.tar.xz
-source_hash = 2f1e960d92ce3b3abd03d06dfec9637dfbd22febf107a536b44f7a47c60659f6
+source_url = https://github.com/glennrp/libpng/archive/v1.6.35.tar.gz
+source_filename = libpng-1.6.35.tar.gz
+source_hash = 6d59d6a154ccbb772ec11772cb8f8beb0d382b61e7ccc62435bf7311c9f4b210
 
-patch_url = https://wrapdb.mesonbuild.com/v1/projects/libpng/1.6.34/1/get_zip
-patch_filename = libpng-1.6.34-1-wrap.zip
-patch_hash = 2123806eba8180c164e33a210f2892bbeb2473b69e56aecc786574e9221e6f20
+patch_url = https://wrapdb.mesonbuild.com/v1/projects/libpng/1.6.35/5/get_zip
+patch_filename = libpng-1.6.35-5-wrap.zip
+patch_hash = da42b18e8d75a88615bdbc1c7bbf1f739ae19f63a8e70d96c90bc448326ae6b7


### PR DESCRIPTION
Cross-compiling for windows with MinGW requires some fixups, please consider applying the attached changes.

FYI I am using this version of cairo to cross-build the Evince PDF reader for Windows with meson using only internal dependencies: https://gitlab.gnome.org/GNOME/evince/issues/1071

I am not sure that the last commit is the best approach, but it makes cairo cross-compilation succeed, feel free to drop it and propose a better solution.

Thanks,
   Antonio